### PR TITLE
Feature/cf template over s3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,3 @@
-# The behavior of RuboCop can be controlled via the .rubocop.yml
-# configuration file. It makes it possible to enable/disable
-# certain cops (checks) and to alter their behavior if they accept
-# any parameters. The file can be placed either in your home
-# directory or in some project directory.
-#
 # RuboCop will start looking for the configuration file in the directory
 # where the inspected file is and continue its way up to the root directory.
 #
@@ -18,6 +12,10 @@ AllCops:
     - 'spec/**/*'
     - 'tmp/*'
 
+
+Layout/BeginEndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: begin
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 Layout/SpaceAroundMethodCallOperator:
@@ -30,6 +28,44 @@ Lint/MixedRegexpCaptureTypes:
 Lint/RaiseException:
   Enabled: true
 Lint/StructNewOverride:
+  Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/HashCompareByIdentity:
+  Enabled: true
+Lint/IdentityComparison:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: true
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/RedundantSafeNavigation:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
+Lint/UselessTimes:
   Enabled: true
 
 Metrics/AbcSize:
@@ -57,4 +93,38 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: true
 Style/SlicingWithRange:
+  Enabled: true
+Style/AccessorGrouping:
+  Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/ClassEqualityComparison:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: true
+Style/GlobalStdStream:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/KeywordParametersOrder:
+  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantSelfAssignment:
+  Enabled: true
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SoleNestedConditional:
+  Enabled: true
+Style/StringConcatenation:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Actions Test Status](https://github.com/jdahlke/awshark/workflows/Tests/badge.svg?branch=develop)](https://github.com/jdahlke/awshark/actions)
 
-Simple commandline for some useful AWS tasks for *EC2* and *S3*.
+Simple Commandline tool for some useful tasks for AWS *EC2*, *S3* and *CloudFormation*.
 
 
 ## Installation
@@ -12,14 +12,27 @@ Simple commandline for some useful AWS tasks for *EC2* and *S3*.
 
 ## Usage
 
-1. List S3 objects
+These are just are few quick examples.
+For a further information visit the [Wiki](https://github.com/jdahlke/awshark/wiki).
+
+1. List all commands
 ```
-exe/awshark s3 list static.bundesimmobilien.de fonts/ --profile=bima
+awshark help
 ```
 
-2. Update cache control for S3 object
+2. List all S3 buckets
 ```
-exe/awshark s3 update_metadata static.bundesimmobilien.de fonts/ --meta=cache_control:"public, max-age=2592000, s-maxage=2592000" acl:public-read --profile=bima
+awshark s3 list --profile=AWS_PROFILE
+```
+
+3. List all objects in a specific S3 bucket
+```
+awshark s3 objects BUCKET_NAME fonts/ --profile=AWS_PROFILE
+```
+
+4. List all EC2 instances in a region
+```
+awshark ec2 list --profile=AWS_PROFILE
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Actions Test Status](https://github.com/jdahlke/awshark/workflows/Tests/badge.svg?branch=develop)](https://github.com/jdahlke/awshark/actions)
 
-Simple Commandline tool for some useful tasks for AWS *EC2*, *S3* and *CloudFormation*.
+Simple command-line tool for some useful tasks for AWS *EC2*, *S3* and *CloudFormation*.
 
 
 ## Installation

--- a/awshark.gemspec
+++ b/awshark.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'aws-sdk-cloudformation'
@@ -38,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '0.86.0'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
+  spec.add_development_dependency 'rubocop', '0.93.1'
 end

--- a/lib/awshark.rb
+++ b/lib/awshark.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/all'
+require 'logger'
 require 'thor'
 require 'yaml'
 
@@ -16,6 +17,18 @@ module Awshark
 
   def self.configure
     yield config
+  end
+
+  def self.logger
+    return @logger if @logger
+
+    @logger = ::Logger.new(STDOUT)
+    @logger.level = Logger::INFO
+    @logger.formatter = proc do |_severity, _datetime, _progname, msg|
+      "[awshark] #{msg}\n"
+    end
+
+    @logger
   end
 end
 

--- a/lib/awshark.rb
+++ b/lib/awshark.rb
@@ -22,7 +22,7 @@ module Awshark
   def self.logger
     return @logger if @logger
 
-    @logger = ::Logger.new(STDOUT)
+    @logger = ::Logger.new($stdout)
     @logger.level = Logger::INFO
     @logger.formatter = proc do |_severity, _datetime, _progname, msg|
       "[awshark] #{msg}\n"

--- a/lib/awshark/cloud_formation/manager.rb
+++ b/lib/awshark/cloud_formation/manager.rb
@@ -6,13 +6,15 @@
 module Awshark
   module CloudFormation
     class Manager
-      attr_reader :path, :stage, :capabilities
-      attr_reader :stack
+      attr_reader :path, :options
+      attr_reader :stack, :stage, :capabilities
 
-      def initialize(path:, stage: nil, iam: false)
+      def initialize(path, options = {})
         @path = path
-        @stage = stage
-        @capabilities = if iam
+        @options = options
+        @stage = options[:stage]
+
+        @capabilities = if options[:iam]
                           %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM]
                         else
                           []
@@ -34,7 +36,7 @@ module Awshark
         stack.create_or_update(
           capabilities: capabilities,
           stack_name: stack.name,
-          template_body: template.body,
+          template_url: template.url,
           parameters: parameters.stack_parameters
         )
       rescue Aws::CloudFormation::Errors::ValidationError => e
@@ -73,7 +75,7 @@ module Awshark
       end
 
       def template
-        @template ||= Template.new(path: path, stage: stage)
+        @template ||= Template.new(path, options.merge(name: stack.name))
       end
 
       def print_stack_events(events)

--- a/lib/awshark/cloud_formation/manager.rb
+++ b/lib/awshark/cloud_formation/manager.rb
@@ -79,7 +79,7 @@ module Awshark
       end
 
       def print_stack_events(events)
-        STDOUT.sync
+        $stdout.sync
         events.each do |event|
           printf "%-30<type>s %-30<logical_id>s %-20<status>s %<reason>s\n",
                  type: event.resource_type,

--- a/lib/awshark/cloud_formation/template.rb
+++ b/lib/awshark/cloud_formation/template.rb
@@ -70,7 +70,8 @@ module Awshark
       end
 
       def s3_key
-        "awshark/#{name}.json"
+        # https://apidock.com/ruby/Time/strftime
+        @s3_key ||= "awshark/#{name}/#{Time.now.strftime('%Y-%m-%d')}.json"
       end
 
       def upload

--- a/lib/awshark/cloud_formation/template.rb
+++ b/lib/awshark/cloud_formation/template.rb
@@ -5,24 +5,20 @@ module Awshark
     class Template
       include FileLoading
 
-      attr_reader :filepath, :path, :stage
+      attr_reader :path
+      attr_reader :bucket, :name, :stage
 
-      def initialize(path:, stage: nil)
+      def initialize(path, options = {})
         @path = path
-        @stage = stage
 
-        @filepath = if File.directory?(path)
-                      Dir.glob("#{path}/template.*").detect do |f|
-                        %w[.json .yml .yaml].include?(File.extname(f))
-                      end
-                    else
-                      path
-                    end
+        @bucket = options[:bucket]
+        @name = options[:name]
+        @stage = options[:stage]
       end
 
       # @returns [Hash]
       def as_json
-        load_file(filepath, context)
+        load_file(template_path, context)
       end
 
       # @returns [String]
@@ -34,11 +30,7 @@ module Awshark
       def context
         return { context: {}, stage: stage } if File.file?(path)
 
-        filepath = Dir.glob("#{path}/context.*").detect do |f|
-          %w[.json .yml .yaml].include?(File.extname(f))
-        end
-
-        context = load_file(filepath) || {}
+        context = load_file(context_path) || {}
         context = context[stage] if context.key?(stage)
 
         {
@@ -46,6 +38,63 @@ module Awshark
           aws_account_id: Awshark.config.aws_account_id,
           stage: stage
         }
+      end
+
+      # @returns [Integer]
+      def size
+        body.size
+      end
+
+      # @returns [Boolean]
+      def uploaded?
+        @uploaded == true
+      end
+
+      # @returns [String]
+      def url
+        upload unless uploaded?
+
+        "https://#{bucket}.s3.#{region}.amazonaws.com/#{s3_key}"
+      end
+
+      private
+
+      def region
+        Aws.config[:region] || 'eu-central-1'
+      end
+
+      def s3
+        return Awshark.config.s3.client if Awshark.config.s3.client
+
+        @s3 ||= Aws::S3::Client.new(region: region, signature_version: 'v4')
+      end
+
+      def s3_key
+        "awshark/#{name}.json"
+      end
+
+      def upload
+        raise ArgumentError, 'Bucket for template upload to S3 is missing' if bucket.blank?
+
+        Awshark.logger.debug "[awshark] Uploading CF template to #{bucket}"
+
+        s3.put_object(bucket: bucket, key: s3_key, body: body)
+      end
+
+      def context_path
+        Dir.glob("#{path}/context.*").detect do |f|
+          %w[.json .yml .yaml].include?(File.extname(f))
+        end
+      end
+
+      def template_path
+        @template_path ||= if File.directory?(path)
+                             Dir.glob("#{path}/template.*").detect do |f|
+                               %w[.json .yml .yaml].include?(File.extname(f))
+                             end
+                           else
+                             path
+                           end
       end
     end
   end

--- a/lib/awshark/configuration.rb
+++ b/lib/awshark/configuration.rb
@@ -2,12 +2,16 @@
 
 module Awshark
   class Configuration
-    attr_accessor :cloud_formation
+    attr_accessor :cloud_formation, :s3
 
     def initialize
       @cloud_formation = OpenStruct.new(
         client: nil,
         event_polling: 3
+      )
+
+      @s3 = OpenStruct.new(
+        client: nil
       )
     end
 

--- a/lib/awshark/profile_resolver.rb
+++ b/lib/awshark/profile_resolver.rb
@@ -48,7 +48,7 @@ module Awshark
 
     def mfa_token
       print %(Please enter MFA token for AWS account #{@profile}: )
-      STDIN.gets.strip
+      $stdin.gets.strip
     end
   end
 end

--- a/lib/awshark/s3/manager.rb
+++ b/lib/awshark/s3/manager.rb
@@ -16,7 +16,7 @@ module Awshark
       def list_objects(bucket:, prefix: nil)
         objects = []
         response = client.list_objects_v2(bucket: bucket, prefix: prefix)
-        objects = objects.concat(response.contents)
+        objects.concat(response.contents)
 
         while response.next_continuation_token
           response = client.list_objects_v2(
@@ -24,7 +24,7 @@ module Awshark
             prefix: prefix,
             continuation_token: response.next_continuation_token
           )
-          objects = objects.concat(response.contents)
+          objects.concat(response.contents)
         end
 
         objects.select { |o| o.size.positive? }

--- a/lib/awshark/subcommands/cloud_formation.rb
+++ b/lib/awshark/subcommands/cloud_formation.rb
@@ -16,6 +16,8 @@ module Awshark
     class CloudFormation < Thor
       include Awshark::Subcommands::ClassOptions
 
+      class_option :bucket, type: :string, desc: 'S3 bucket for template'
+      class_option :iam, type: :boolean, desc: 'Needs IAM capabilities'
       class_option :stage, type: :string, desc: 'Stage of the configuration'
 
       desc 'deploy', 'Updates or creates an AWS CloudFormation stack'
@@ -30,10 +32,10 @@ module Awshark
 
           awshark cf deploy iam_template IAM
       LONGDESC
-      def deploy(template_path, iam = '')
+      def deploy(template_path)
         process_class_options
 
-        manager = create_manager(template_path, iam == 'IAM')
+        manager = create_manager(template_path)
         print_stack_information(manager.stack)
 
         manager.update_stack
@@ -61,12 +63,8 @@ module Awshark
 
       private
 
-      def create_manager(template_path, iam = false)
-        Awshark::CloudFormation::Manager.new(
-          path: template_path,
-          stage: options['stage'],
-          iam: iam
-        )
+      def create_manager(template_path)
+        Awshark::CloudFormation::Manager.new(template_path, options.symbolize_keys)
       end
 
       def print_stack_information(stack)

--- a/spec/cloud_formation/manager_spec.rb
+++ b/spec/cloud_formation/manager_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Awshark::CloudFormation::Manager do
   let(:path) { 'spec/fixtures/cloud_formation/yaml' }
   let(:stage) { 'test' }
-  let(:manager) { described_class.new(path: path, stage: stage) }
+  let(:manager) { described_class.new(path, stage: stage, bucket: 'foobar') }
 
 
   describe '#stack' do

--- a/spec/cloud_formation/template_spec.rb
+++ b/spec/cloud_formation/template_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Awshark::CloudFormation::Template do
-  let(:template) { described_class.new(path: path, stage: stage) }
+  let(:template) { described_class.new(path, name: 'foo', stage: stage) }
   let(:stage) { nil }
 
   json_path = 'spec/fixtures/cloud_formation/json'
@@ -104,6 +104,27 @@ RSpec.describe Awshark::CloudFormation::Template do
       let(:path) { 'spec/fixtures/cloud_formation/empty' }
 
       it { is_expected.to eq({ aws_account_id: 'accountType', context: {}, stage: 'test' }) }
+    end
+  end
+
+  describe '#url' do
+    subject { template.url }
+    let(:path) { yaml_path }
+
+    context 'without bucket' do
+      it 'raises ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with bucket' do
+      let(:template) do
+        described_class.new(path, name: 'foo', stage: stage, bucket: 'foobar')
+      end
+
+      it 'returns S3 object url of template' do
+        is_expected.to eq('https://foobar.s3.eu-central-1.amazonaws.com/awshark/foo.json')
+      end
     end
   end
 end

--- a/spec/cloud_formation/template_spec.rb
+++ b/spec/cloud_formation/template_spec.rb
@@ -118,12 +118,14 @@ RSpec.describe Awshark::CloudFormation::Template do
     end
 
     context 'with bucket' do
+      let(:bucket) { 'foobar' }
       let(:template) do
-        described_class.new(path, name: 'foo', stage: stage, bucket: 'foobar')
+        described_class.new(path, name: 'foo', stage: stage, bucket: bucket)
       end
 
       it 'returns S3 object url of template' do
-        is_expected.to eq('https://foobar.s3.eu-central-1.amazonaws.com/awshark/foo.json')
+        s3_key = "awshark/foo/#{Time.now.strftime('%Y-%m-%d')}.json"
+        is_expected.to eq("https://#{bucket}.s3.eu-central-1.amazonaws.com/#{s3_key}")
       end
     end
   end

--- a/spec/support/mocks.rb
+++ b/spec/support/mocks.rb
@@ -3,24 +3,35 @@
 module Mocks
   def self.stub_aws
     Awshark.config.send(:sts_client=, Aws::STS::Client.new(stub_responses: true))
-    stub_cloudformation
+    CloudFormation.stub
+    S3.stub
   end
 
   def self.unstub_aws
     Awshark.config.send(:sts_client=, nil)
-    unstub_cloudformation
+    CloudFormation.unstub
+    S3.unstub
   end
 
-  def self.stub_cloudformation
-    client = Aws::CloudFormation::Client.new(
-      region: 'us-east-1',
-      stub_responses: true
-    )
+  module CloudFormation
+    def self.stub
+      client = Aws::CloudFormation::Client.new(region: 'us-east-1', stub_responses: true)
+      Awshark.config.cloud_formation.client = client
+    end
 
-    Awshark.config.cloud_formation.client = client
+    def self.unstub
+      Awshark.config.cloud_formation.client = nil
+    end
   end
 
-  def self.unstub_cloudformation
-    Awshark.config.cloud_formation.client = nil
+  module S3
+    def self.stub
+      client = Aws::S3::Client.new(region: 'us-east-1', stub_responses: true)
+      Awshark.config.s3.client = client
+    end
+
+    def self.unstub
+      Awshark.config.s3.client = nil
+    end
   end
 end


### PR DESCRIPTION
Upload Cloud Formation template to S3 instead and sent the S3 object url to Cloud Formation.

Advantages
* can now create templates bigger than 50KB
* template history on S3
