### PR TITLE
Feature/improve cloudformation template context

### DIFF
--- a/awshark.gemspec
+++ b/awshark.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'diffy'
   spec.add_dependency 'mini_mime'
+  spec.add_dependency 'recursive-open-struct'
   spec.add_dependency 'thor', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/awshark/cloud_formation/template.rb
+++ b/lib/awshark/cloud_formation/template.rb
@@ -28,16 +28,16 @@ module Awshark
 
       # @returns [Hash]
       def context
-        return { context: {}, stage: stage } if File.file?(path)
+        @context ||= begin
+                       context = load_file(context_path) || {}
+                       context = context[stage] if context.key?(stage)
 
-        context = load_file(context_path) || {}
-        context = context[stage] if context.key?(stage)
-
-        {
-          context: HashWithIndifferentAccess.new(context),
-          aws_account_id: Awshark.config.aws_account_id,
-          stage: stage
-        }
+                       {
+                         context: RecursiveOpenStruct.new(context),
+                         aws_account_id: Awshark.config.aws_account_id,
+                         stage: stage
+                       }
+                     end
       end
 
       # @returns [Integer]

--- a/lib/awshark/subcommands/cloud_formation.rb
+++ b/lib/awshark/subcommands/cloud_formation.rb
@@ -2,6 +2,7 @@
 
 require 'aws-sdk-cloudformation'
 require 'diffy'
+require 'recursive-open-struct'
 
 require 'awshark/cloud_formation/file_loading'
 require 'awshark/cloud_formation/inferrer'

--- a/spec/cloud_formation/template_spec.rb
+++ b/spec/cloud_formation/template_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Awshark::CloudFormation::Template do
       it do
         is_expected.to eq({
           aws_account_id: 'accountType',
-          context: { 'S3Bucket' => 'foo.bar.org' },
+          context: RecursiveOpenStruct.new({ 'S3Bucket' => 'foo.bar.org' }),
           stage: 'test'
         })
       end
@@ -82,13 +82,13 @@ RSpec.describe Awshark::CloudFormation::Template do
       it do
         is_expected.to eq({
           aws_account_id: 'accountType',
-          context: {
+          context: RecursiveOpenStruct.new({
             'QueueName' => 'Foo',
             'Instances' => [
               { 'Name'=>'foo', 'Type'=>'small' },
               { 'Name'=>'bar', 'Type'=>'medium' }
             ],
-          },
+          }),
           stage: 'test'
         })
       end
@@ -97,13 +97,25 @@ RSpec.describe Awshark::CloudFormation::Template do
     context 'with file path' do
       let(:path) { 'spec/fixtures/cloud_formation/yaml/template.yml' }
 
-      it { is_expected.to eq({ aws_account_id: 'accountType', context: {}, stage: 'test' }) }
+      it do
+        is_expected.to eq({
+          aws_account_id: 'accountType',
+          context: RecursiveOpenStruct.new,
+          stage: 'test'
+        })
+      end
     end
 
     context 'with no context file' do
       let(:path) { 'spec/fixtures/cloud_formation/empty' }
 
-      it { is_expected.to eq({ aws_account_id: 'accountType', context: {}, stage: 'test' }) }
+      it do
+        is_expected.to eq({
+          aws_account_id: 'accountType',
+          context: RecursiveOpenStruct.new,
+          stage: 'test'
+        })
+      end
     end
   end
 

--- a/spec/fixtures/cloud_formation/yaml/template.yaml
+++ b/spec/fixtures/cloud_formation/yaml/template.yaml
@@ -14,7 +14,7 @@ Resources:
   TestQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: <%= context['QueueName'] %>
+      QueueName: <%= context.QueueName %>
   AlarmTopic:
     Type: AWS::SNS::Topic
     Properties:


### PR DESCRIPTION
Allow dot notation in ERB templates.

For example `<%= context.QueueName %>` instead of `<%= context['QueueName'] %>`.
