### PR TITLE
[cf] add "cf save" command to save stack template as file

### DIFF
--- a/lib/awshark/cloud_formation/manager.rb
+++ b/lib/awshark/cloud_formation/manager.rb
@@ -46,6 +46,12 @@ module Awshark
         raise e
       end
 
+      def save_stack_template
+        filename = "#{stack.name}.json"
+        File.open(filename, 'w') { |f| f.write(template.body) }
+        filename
+      end
+
       def tail_stack_events
         stack.reload
         stack_events = StackEvents.new(stack)

--- a/lib/awshark/cloud_formation/subcommand.rb
+++ b/lib/awshark/cloud_formation/subcommand.rb
@@ -63,6 +63,22 @@ module Awshark
         puts diff
       end
 
+      desc 'save', 'Save AWS CloudFormation JSON template as file'
+      long_desc <<-LONGDESC
+        Save AWS CloudFormation JSON template as file TEMPLATE_PATH/cloudformation-stage.json
+
+        Example: `awshark cf save TEMPLATE_PATH`
+      LONGDESC
+      def save(template_path)
+        process_class_options
+
+        manager = create_manager(template_path)
+        print_stack_information(manager.stack)
+
+        filename = manager.save_stack_template
+        printf "Written CloudFormation JSON template to: %<name>s\n\n", name: filename
+      end
+
       private
 
       def create_manager(template_path)

--- a/spec/cloud_formation/manager_spec.rb
+++ b/spec/cloud_formation/manager_spec.rb
@@ -23,4 +23,20 @@ RSpec.describe Awshark::CloudFormation::Manager do
       expect { manager.update_stack }.to_not raise_error
     end
   end
+
+  describe '#save_stack_template' do
+    after do
+      filename = 'yaml-test.json'
+      File.delete(filename) if File.exist?(filename)
+    end
+
+    it 'does not raise error' do
+      expect { manager.save_stack_template }.to_not raise_error
+    end
+
+    it 'writes Cloud Formation template to file' do
+      filename = manager.save_stack_template
+      expect(File.exist?(filename)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
```
% AWS_PROFILE=XXXXX bin/awshark cf save spec/fixtures/cloud_formation/yaml
Stack: yaml

Written CloudFormation JSON template to: yaml.json
```

```
% cat yaml.json 
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "AWS CloudFormation Sample Template SQS_With_CloudWatch_Alarms: Sample template showing how to create an SQS queue with AWS CloudWatch alarms on queue depth. **WARNING** This template creates an Amazon SQS Queue and one or more Amazon CloudWatch alarms. You will be billed for the AWS resources used if you create a stack from this template.",
  "Parameters": {
    "AlarmEMail": {
      "Description": "EMail address to notify if there are any operational issues",
      "Type": "String",
     ...
```